### PR TITLE
Fixed XXE Vulnerability when parsing 'nmap_data'

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ install:
   - "pip install pyflakes"
 #  - "pip install boto" # disabled: since boto not supporting py3
 #  - "pip install pymongo sqlalchemy MySQL-python" # disabled MySQL-python (not py3 compatible)
-  - "pip install pymongo sqlalchemy pymysql"
+  - "pip install pymongo sqlalchemy pymysql defusedxml"
   - "pip install coveralls"
   - "python setup.py install"
 before_script:

--- a/libnmap/parser.py
+++ b/libnmap/parser.py
@@ -2,9 +2,9 @@
 
 
 try:
-    import xml.etree.cElementTree as ET
+    import defusedxml.cElementTree as parseXML
 except ImportError:
-    import xml.etree.ElementTree as ET
+    import defusedxml.ElementTree as parseXML
 from libnmap.objects import NmapHost, NmapService, NmapReport
 
 
@@ -87,7 +87,7 @@ class NmapParser(object):
             nmap_data += "</nmaprun>"
 
         try:
-            root = ET.fromstring(nmap_data)
+            root = parseXML.fromstring(nmap_data)
         except:
             raise NmapParserException("Wrong XML structure: cannot parse data")
 

--- a/tox.ini
+++ b/tox.ini
@@ -5,4 +5,5 @@ deps=nose
      pymongo
      sqlalchemy
      pymysql
+     defusedxml
 commands=nosetests


### PR DESCRIPTION
The standard XML library is vulnerable to XXE (XML External Entity) attacks such as "Billion Laughs" XXE bomb attack. This issue has been raised on Feb 2018 (https://github.com/savon-noir/python-libnmap/issues/87) and haven't been mitigated because there were no good solutions for this vulnerability.

Although there has been discussions of these vulnerabilities in Python's official bug tracker (https://bugs.python.org/issue17239) which helped me come up with a solution that is to use 'defusedxml' instead of the standard 'xml' module which is a XML bomb protection for Python stdlib modules.

**Fixed!** :+1: 